### PR TITLE
Added rudimentary store searching and model for products in the store

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,9 @@ Usage
 Basic usage looks something like::
 
     client = humblebundle.HumbleApi()
+    
+    client.search_store("ftl")
+    
     client.login("username@example.com", "secret")
     
     order_list = client.order_list()

--- a/humblebundle/handlers.py
+++ b/humblebundle/handlers.py
@@ -146,3 +146,9 @@ def sign_download_url_handler(client, response):
     # If the user isn't signed in we get a "typical" error response
     if authenticated_response_helper(response, data):
         return data['signed_url']
+        
+def store_products_handler(client, response):
+    """ Takes a results from the store as JSON and converts it to object """
+    
+    data = parse_data(response)
+    return [StoreProduct(client, result) for result in data['results']]

--- a/humblebundle/models.py
+++ b/humblebundle/models.py
@@ -58,7 +58,18 @@ class Product(BaseModel):
 
     def __repr__(self):
         return "Product: <%s>" % self.machine_name
+        
+class StoreProduct(BaseModel):
+    def __init__(self, client, data):
+        super(StoreProduct, self).__init__(client, data)
+        self.category = data.get(1, None)
+        self.human_name = data['human_name']
+        self.machine_name = data['machine_name']
+        self.current_price = Price(client, data['current_price'])
+        self.full_price = Price(client, data['full_price'])
 
+    def __repr__(self):
+        return "StoreProduct: <%s>" % self.machine_name
 
 class Subscription(BaseModel):
     def __init__(self, client, data):
@@ -135,3 +146,24 @@ class Url(BaseModel):
         super(Url, self).__init__(client, data)
         self.web = data.get('web', None)
         self.bittorrent = data.get('bittorrent', None)
+
+class Price(BaseModel):
+    def __init__(self, client, data):
+        super(Price, self).__init__(client, data)
+        self.value = data[0]
+        self.currency = data[1]
+        
+    def __cmp__(self, other):
+        if other.currency == self.currency:
+            if self.value < other.value:
+                return -1
+            elif self.value > other.value:
+                return 1
+            else:
+                return 0
+        else:
+            raise NotImplemented("Mixed currencies cannot be compared")
+
+    def __repr__(self):
+        return "Price: <{value:.2f}{currency}>".format(value=self.value, currency=self.currency)
+


### PR DESCRIPTION
This patch adds the ability to use the unofficial store API at `https://www.humblebundle.com/store/api/humblebundle` to search the store for products, or even get a list all items in the store.

It is not yet feature complete as it was purely to fill my need to get and compare the prices of products in the store. It would be possible to extend it to search based upon DRM and OS in future, and potentially even purchase products.
