### PR TITLE
Order List now retrieves each product separately

### DIFF
--- a/humblebundle/handlers.py
+++ b/humblebundle/handlers.py
@@ -95,7 +95,7 @@ def order_list_handler(client, response):
     data = parse_data(response)
 
     if isinstance(data, list):
-        return [Order(client, order) for order in data]
+        return [client.order(order['gamekey']) for order in data]
 
     # Let the helper function raise any common exceptions
     authenticated_response_helper(response, data)


### PR DESCRIPTION
Fixed an issue with retrieving the list of orders `order_list` where the returned list was just a bunch of IDs rather than the complete product data as per the previous code (and previous API presumably).
