### PR TITLE
Order List now returns GameKey object

### DIFF
--- a/humblebundle/handlers.py
+++ b/humblebundle/handlers.py
@@ -95,7 +95,7 @@ def order_list_handler(client, response):
     data = parse_data(response)
 
     if isinstance(data, list):
-        return [client.order(order['gamekey']) for order in data]
+        return [GameKey(client, order) for order in data]
 
     # Let the helper function raise any common exceptions
     authenticated_response_helper(response, data)

--- a/humblebundle/models.py
+++ b/humblebundle/models.py
@@ -22,6 +22,13 @@ class BaseModel(object):
     def __iter__(self):
         return self.__dict__.__iter__()
 
+class GameKey(BaseModel):
+    def __init__(self, client, data):
+        super(GameKey, self).__init__(client, data)
+        self.gamekey = data['gamekey']
+
+    def __repr__(self):
+        return "GameKey: <{gamekey}>".format(gamekey=self.gamekey)
 
 class Order(BaseModel):
     def __init__(self, client, data):


### PR DESCRIPTION
So this is one alternative. It could also just return a string, but then a decision needs to be made about how `client.order` method is called. Should it accept a string? A GameKey object? Both?
