### PR TITLE
add requesting csrf token for fixing login

### DIFF
--- a/humblebundle/client.py
+++ b/humblebundle/client.py
@@ -16,6 +16,8 @@ import humblebundle.handlers as handlers
 import requests
 from logging import getLogger, NullHandler
 
+import re
+
 LOGIN_URL = 'https://www.humblebundle.com/login'
 ORDER_LIST_URL = 'https://www.humblebundle.com/api/v1/user/order'
 ORDER_URL = 'https://www.humblebundle.com/api/v1/order/{order_id}'
@@ -106,6 +108,21 @@ class HumbleApi(object):
             'authy-token': authy_token,
             'recaptcha_challenge_field': recaptcha_challenge,
             'recaptcha_response_field': recaptcha_response}
+
+        # We will need a valid csrf token
+
+        # Pull down the LOGIN_URL in a GET request and pull the csrf token
+        response = self._request('GET', LOGIN_URL, [], {})
+
+        matches = re.search(r'<input([^>]*?)name\s*=\s*["\']_le_csrf_token["\']([^>]*?)>', response.text)
+        if not matches is None:
+            # Parse the value from the input attribute to provide the token
+            value = "%s %s" % (matches.group(1), matches.group(2))
+            matches = re.search(r'value\s*=\s*["\'](.*?)["\']', value)
+
+        if not matches is None:
+            default_data["_le_csrf_token"] = matches.group(1)
+
         kwargs.setdefault('data', {}).update({k: v for k, v in default_data.items() if v is not None})
 
         response = self._request('POST', LOGIN_URL, *args, **kwargs)


### PR DESCRIPTION
The login process for humble bundle now requires a valid csrf token. You
just need to prove you are the client. This code simply pulls down the
login form and duplicates the csrf token given in that form within the
body of the login POST request that follows.

It just pulls out the token using a regular expression. The expression
should be robust enough to handle any slight changes and shouldn't break
as long as the key being used does not change.
