### PR TITLE
Update login URL

### DIFF
--- a/humblebundle/client.py
+++ b/humblebundle/client.py
@@ -16,7 +16,7 @@ import humblebundle.handlers as handlers
 import requests
 from logging import getLogger, NullHandler
 
-LOGIN_URL = 'https://www.humblebundle.com/login'
+LOGIN_URL = 'https://www.humblebundle.com/processlogin'
 ORDER_LIST_URL = 'https://www.humblebundle.com/api/v1/user/order'
 ORDER_URL = 'https://www.humblebundle.com/api/v1/order/{order_id}'
 CLAIMED_ENTITIES_URL = 'https://www.humblebundle.com/api/v1/user/claimed/entities'


### PR DESCRIPTION
It seems the login URL changed from /login to /processlogin.

I noticed there already exists a different pull which attempts to fix logging in, #7. However this patch seems to fix logging in for me by itself...
