### PR TITLE
Various login fixes, add email two-factor auth, add logout

### DIFF
--- a/humblebundle/client.py
+++ b/humblebundle/client.py
@@ -19,6 +19,7 @@ import humblebundle.handlers as handlers
 
 
 LOGIN_URL = 'https://www.humblebundle.com/processlogin'
+LOGOUT_URL = 'https://www.humblebundle.com/logout'
 ORDER_LIST_URL = 'https://www.humblebundle.com/api/v1/user/order'
 ORDER_URL = 'https://www.humblebundle.com/api/v1/order/{order_id}'
 CLAIMED_ENTITIES_URL = 'https://www.humblebundle.com/api/v1/user/claimed/entities'
@@ -114,6 +115,16 @@ class HumbleApi(object):
 
         response = self._request('POST', LOGIN_URL, *args, **kwargs)
         return handlers.login_handler(self, response)
+
+
+    @callback
+    def logout(self, *args, **kwargs):
+        """
+        Logout of the Humble Bundle API.
+        """
+        self.logger.info("Logging out")
+        self._request('POST', LOGOUT_URL, *args, **kwargs)
+
 
     @callback
     def get_gamekeys(self, *args, **kwargs):

--- a/humblebundle/client.py
+++ b/humblebundle/client.py
@@ -18,7 +18,7 @@ from humblebundle.exceptions import *
 import humblebundle.handlers as handlers
 
 
-LOGIN_URL = 'https://www.humblebundle.com/login'
+LOGIN_URL = 'https://www.humblebundle.com/processlogin'
 ORDER_LIST_URL = 'https://www.humblebundle.com/api/v1/user/order'
 ORDER_URL = 'https://www.humblebundle.com/api/v1/order/{order_id}'
 CLAIMED_ENTITIES_URL = 'https://www.humblebundle.com/api/v1/user/claimed/entities'

--- a/humblebundle/client.py
+++ b/humblebundle/client.py
@@ -76,7 +76,7 @@ class HumbleApi(object):
 
     @callback
     def login(self, username, password, authy_token=None, recaptcha_challenge=None, recaptcha_response=None,
-              *args, **kwargs):
+              guard_token=None, *args, **kwargs):
         """
         Login to the Humble Bundle API. The response sets the _simpleauth_sess cookie which is stored in the session
         automatically.
@@ -107,6 +107,7 @@ class HumbleApi(object):
             'username': username,
             'password': password,
             'authy-token': authy_token,
+            'guard': guard_token,
             'recaptcha_challenge_field': recaptcha_challenge,
             'recaptcha_response_field': recaptcha_response}
         kwargs.setdefault('data', {}).update({k: v for k, v in default_data.items() if v is not None})

--- a/humblebundle/exceptions.py
+++ b/humblebundle/exceptions.py
@@ -9,7 +9,8 @@ __copyright__ = "Copyright 2014, Joel Pedraza"
 __license__ = "MIT"
 
 __all__ = ['HumbleException', 'HumbleResponseException', 'HumbleAuthenticationException', 'HumbleCredentialException',
-           'HumbleCaptchaException', 'HumbleTwoFactorException', 'HumbleParseException']
+           'HumbleCaptchaException', 'HumbleTwoFactorException', 'HumbleTwoFactorAuthyException',
+           'HumbleTwoFactorGuardException', 'HumbleParseException']
 
 from requests import RequestException
 
@@ -38,6 +39,7 @@ class HumbleAuthenticationException(HumbleResponseException):
     def __init__(self, *args, **kwargs):
         self.captcha_required = kwargs.pop('captcha_required', None)
         self.authy_required = kwargs.pop('authy_required', None)
+        self.guard_required = kwargs.pop('guard_required', None)
         super(HumbleAuthenticationException, self).__init__(*args, **kwargs)
 
 
@@ -58,6 +60,20 @@ class HumbleCaptchaException(HumbleAuthenticationException):
 class HumbleTwoFactorException(HumbleAuthenticationException):
     """
     The one time password was invalid
+    """
+    pass
+
+
+class HumbleTwoFactorAuthyException(HumbleTwoFactorException):
+    """
+    The Authy token was invalid
+    """
+    pass
+
+
+class HumbleTwoFactorGuardException(HumbleTwoFactorException):
+    """
+    The Humble Guard token was invalid or missing
     """
     pass
 

--- a/humblebundle/handlers.py
+++ b/humblebundle/handlers.py
@@ -91,7 +91,7 @@ def login_handler(client, response):
     # Looks like Humble Guard doesn't use the errors object.
     # It responds identically whether token is missing or wrong.
     if guard_required:
-        raise HumbleTwoFactorGuardException(error_msg, request=response.request, response=response,
+        raise HumbleTwoFactorGuardException("Humble Guard token required", request=response.request, response=response,
                                        captcha_required=captcha_required, authy_required=authy_required,
                                        guard_required=guard_required)
 

--- a/humblebundle/handlers.py
+++ b/humblebundle/handlers.py
@@ -66,26 +66,38 @@ def login_handler(client, response):
 
     captcha_required = data.get('captcha_required')
     authy_required = data.get('authy_required')
+    guard_required = data.get('humble_guard_required')
 
     errors, error_msg = get_errors(data)
     if errors:
         captcha = errors.get('captcha')
         if captcha:
             raise HumbleCaptchaException(error_msg, request=response.request, response=response,
-                                         captcha_required=captcha_required, authy_required=authy_required)
+                                         captcha_required=captcha_required, authy_required=authy_required,
+                                         guard_required=guard_required)
 
         username = errors.get('username')
         if username:
             raise HumbleCredentialException(error_msg, request=response.request, response=response,
-                                            captcha_required=captcha_required, authy_required=authy_required)
+                                            captcha_required=captcha_required, authy_required=authy_required,
+                                            guard_required=guard_required)
 
         authy_token = errors.get("authy-token")
         if authy_token:
-            raise HumbleTwoFactorException(error_msg, request=response.request, response=response,
-                                           captcha_required=captcha_required, authy_required=authy_required)
+            raise HumbleTwoFactorAuthyException(error_msg, request=response.request, response=response,
+                                           captcha_required=captcha_required, authy_required=authy_required,
+                                           guard_required=guard_required)
+
+    # Looks like Humble Guard doesn't use the errors object.
+    # It responds identically whether token is missing or wrong.
+    if guard_required:
+        raise HumbleTwoFactorGuardException(error_msg, request=response.request, response=response,
+                                       captcha_required=captcha_required, authy_required=authy_required,
+                                       guard_required=guard_required)
 
     raise HumbleAuthenticationException(error_msg, request=response.request, response=response,
-                                        captcha_required=captcha_required, authy_required=authy_required)
+                                        captcha_required=captcha_required, authy_required=authy_required,
+                                        guard_required=guard_required)
 
 
 def gamekeys_handler(client, response):

--- a/humblebundle/handlers.py
+++ b/humblebundle/handlers.py
@@ -61,8 +61,7 @@ def login_handler(client, response):
 
     data = parse_data(response)
 
-    success = data.get('success', None)
-    if success is True:
+    if response.status_code == 200:
         return True
 
     captcha_required = data.get('captcha_required')

--- a/humblebundle/models.py
+++ b/humblebundle/models.py
@@ -49,7 +49,7 @@ class Product(BaseModel):
         self.category = data.get(1, None)
         self.human_name = data['human_name']
         self.machine_name = data['machine_name']
-        self.supports_canonical = data['supports_canonical']
+        self.supports_canonical = data.get('supports_canonical')
 
     def __repr__(self):
         return "Product: <%s>" % self.machine_name


### PR DESCRIPTION
I can break this PR up, but I figure it would be easier for you to merge it in all at once.

- Fix login
- Add email-based two-factor authentication (Humble Guard)
- Add a logout method
- Make supports_canonical attribute optional (I have no idea what this is, and none of my extensive collection has it, so it's probably gone from the API completely)